### PR TITLE
Fix recipe to work with latest rattler-build release

### DIFF
--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -16,9 +16,10 @@ source:
 build:
   noarch: python
   script: python -m pip install . -vv
-  number: 0
+  number: 1
   python:
-    entry_points: bagels = bagels.__main__:cli
+    entry_points:
+      - bagels = bagels.__main__:cli
 
 requirements:
   host:


### PR DESCRIPTION
Convert scalar fields to YAML sequences where required (entry_points, requirements.run, source.patches, files.source, etc.).